### PR TITLE
Fix missing comma in predict.py

### DIFF
--- a/model/infer/predict.py
+++ b/model/infer/predict.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
             args.tokenizer_path = args.base_model
     tokenizer = AutoTokenizer.from_pretrained(
         args.tokenizer_path, 
-        trust_remote_code=True
+        trust_remote_code=True,
         resume_download=True,
     )
 


### PR DESCRIPTION
There is a missing comma in `predict.py`, that would raise a `SyntaxError`.